### PR TITLE
feat: track per-bookmark LLM token usage and USD costs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,12 @@ SMTP_TO=alerts@example.com
 # DEFAULT_TICKER=BTCUSDT
 # DEFAULT_TIMEFRAME=D
 
+# CDP auto-consent: Chrome browser automation for OAuth reauth
+# Set a dedicated user-data-dir to enable automatic "Authorize app" clicks.
+# Chrome will be launched with --remote-debugging-port=0 using this profile.
+# XPB_CHROME_USER_DATA_DIR=/Users/you/.chrome-oauth-profile
+# XPB_CHROME_BINARY=/Applications/Google Chrome.app/Contents/MacOS/Google Chrome
+
 # Daemon behavior
 # XPB_DAEMON=true
 # XPB_DAEMON_INTERVAL_SECONDS=300

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ This repository is a Rust implementation of the X bookmark pipeline with shared 
 - `orchestrator.rs` coordinates bounded worker parallelism and `on_meta_saved` side effects.
 - `notify.rs` implements `SmtpNotifier` via `lettre`.
 - `error.rs` centralizes `PipelineError` and conversion of external failures.
+- `browser.rs` implements CDP (Chrome DevTools Protocol) auto-consent for OAuth reauth.
+- `cost.rs` tracks per-bookmark LLM token usage and USD costs with per-provider pricing.
 - `main.rs` handles startup, env loading, provider bootstrap, and CLI dispatch.
 
 ## Setup
@@ -50,6 +52,8 @@ Optional runtime tuning:
 - `XPB_DAEMON` / `DAEMON_MODE`
 - `DAEMON_INTERVAL_SECONDS` / `XPB_DAEMON_INTERVAL_SECONDS`
 - `DAEMON_MAX_CYCLES` / `XPB_DAEMON_MAX_CYCLES`
+- `XPB_CHROME_USER_DATA_DIR` — dedicated Chrome profile for CDP auto-consent
+- `XPB_CHROME_BINARY` — Chrome binary path override
 
 ## Notes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +412,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +442,8 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1463,6 +1482,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,6 +1739,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,6 +1834,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,6 +1885,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -2308,6 +2373,7 @@ dependencies = [
  "base64",
  "clap",
  "dotenvy",
+ "futures-util",
  "lettre",
  "regex",
  "reqwest",
@@ -2317,6 +2383,7 @@ dependencies = [
  "sha2",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-tungstenite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,6 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "sync", "time", "fs"] }
+tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "sync", "time", "fs", "net", "io-util"] }
+tokio-tungstenite = "0.26"
+futures-util = "0.3"

--- a/README.md
+++ b/README.md
@@ -1,127 +1,292 @@
 # X Bookmarks Pipeline
 
-The X Bookmarks Pipeline automates end-to-end processing of X (Twitter) bookmarks into trading artifacts. It:
+Convert **X (Twitter) bookmarks into trading strategies**.
 
-- Loads bookmarks from the X API or local input
-- Classifies whether a bookmark is finance-related
-- Optionally analyzes chart images (vision)
-- Generates a Pine Script v6 strategy/reasoning payload
-- Validates generated scripts and writes artifacts for review/deployment
-- Stores intermediate/final results in SQLite for idempotent reruns
-- Sends email notifications for completed metadata writes and daemon cycle summaries
+This pipeline ingests bookmarks, detects finance-related content,
+analyzes charts, and generates **validated Pine Script strategies**
+ready for review or deployment.
 
-## Features
+It is built in **Rust**, runs asynchronously, and is safe to rerun
+thanks to persistent caching.
 
-- Multi-provider LLM orchestration (`Cerebras`, `xAI`, `Claude`, `OpenAI`)
-- Async parallel execution with bounded worker concurrency
-- Optional vision fallback and cache reuse across stages
-- Persistent caching by bookmark id (`classification`, `plan`, `script`, validation, and completion state)
-- Daemon mode for periodic polling and incremental processing
-- Structured errors and robust retry-safe cache lock handling
+------------------------------------------------------------------------
 
-## Repository layout
+# Features
 
-```text
-.
-├── Cargo.toml             # Rust crate manifest
-├── Cargo.lock
-├── src/
-│   ├── llm.rs             # LLM provider abstraction + implementations
-│   ├── cache.rs           # SQLite cache and migration helpers
-│   ├── orchestrator.rs    # Pipeline orchestration + hooks
-│   ├── notify.rs          # Native SMTP notifications
-│   ├── error.rs           # PipelineError/structured failures
-│   └── ...
-├── tests/
-│   └── dotenv_bootstrap.rs # CLI integration sanity test
-├── .env.example
-└── CLAUDE.md
-```
+-   Multi-provider LLM orchestration (`Cerebras`, `xAI`, `Claude`,
+    `OpenAI`)
+-   Parallel processing with bounded worker concurrency
+-   Optional vision analysis for chart screenshots
+-   Persistent SQLite caching (idempotent reruns)
+-   Daemon mode for continuous bookmark ingestion
+-   Automatic OAuth reauth with CDP auto-consent (zero manual intervention)
+-   Email notifications for completed runs
+-   Structured error handling and retry-safe execution
 
-The runtime entrypoint is `src/main.rs` and execution is in this crate root.
+------------------------------------------------------------------------
 
-## Setup
+# Quickstart
 
-```bash
+Clone the repository and configure environment variables.
+
+``` bash
 cp .env.example .env
 cargo build
 ```
 
-Optional: run tests before first use.
+Run tests:
 
-```bash
+``` bash
 cargo test
 ```
 
-## Required and optional environment variables
+Run the pipeline:
 
-- Required for end-to-end execution: `CEREBRAS_API_KEY`, `XAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`
-- Optional fetch auth configuration: `X_BEARER_TOKEN`, `X_ACCESS_TOKEN`, `X_USER_ACCESS_TOKEN`
-- Optional automatic refresh configuration: `X_CLIENT_ID` / `XPB_X_CLIENT_ID`, `X_CLIENT_SECRET` / `XPB_X_CLIENT_SECRET`, `X_REFRESH_TOKEN` / `XPB_X_REFRESH_TOKEN`
-- Optional notification configuration: `SMTP_HOST`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_FROM`, `SMTP_TO`
-- Optional model/runner configuration: `CEREBRAS_MODEL`, `XAI_MODEL`, `ANTHROPIC_MODEL`, `OPENAI_MODEL`, `CACHE_PATH`, `MAX_WORKERS`, `API_TIMEOUT`, `VISION_TIMEOUT`, `FETCH_TIMEOUT`, `DEFAULT_TICKER`, `DEFAULT_TIMEFRAME`
-- Optional X fetch configuration: `X_FETCH_USER_ID`, `X_FETCH_USERNAME`, `XPB_X_FETCH_USER_ID`, `XPB_X_FETCH_USERNAME`
-- Optional daemon scheduling configuration: `XPB_DAEMON`, `XPB_DAEMON_INTERVAL_SECONDS`, `XPB_DAEMON_MAX_CYCLES`, `XPB_FETCH_LOOP`
-
-## Build, test, and run
-
-```bash
-cargo build
-cargo test
-# one-time execution from text input
+``` bash
 cargo run -- --text "BTC 4h bullish momentum and breakout"
+```
 
-# periodic mode (polling)
+------------------------------------------------------------------------
+
+# Usage
+
+## Process X bookmarks
+
+``` bash
+cargo run -- --fetch --fetch-user-id <x_user_id>
+```
+
+## Process a local file
+
+``` bash
+cargo run -- --file bookmarks.json
+```
+
+## Process a single text input
+
+``` bash
+cargo run -- --text "ETH breakout after key support hold"
+```
+
+## Run continuously (daemon mode)
+
+``` bash
 cargo run -- --daemon --daemon-interval 300
 ```
 
-`cargo run` executes the orchestrator workflow.
+When daemon mode is enabled the pipeline:
 
-When daemon mode is enabled, per-bookmark notifications are sent from the SMTP notifier (if configured), and a cycle summary is also sent for each non-empty batch.
+-   polls for new bookmarks
+-   processes them incrementally
+-   sends per-bookmark notifications
+-   sends a summary email per cycle
 
-## Authentication behavior
+------------------------------------------------------------------------
 
-The CLI validates authentication at startup for every command (except explicit OAuth helper commands `--auth-url` and `--auth-code`).
+# Dry run
 
-- If a usable token is present, the run continues.
-- If the token is missing/expired and refresh credentials are available (`X_REFRESH_TOKEN` + `X_CLIENT_ID`), it attempts automatic refresh.
-- If the token is missing/expired and refresh fails (or no refresh credentials are available), it launches the browser OAuth flow automatically and exits with instructions.
+Disable external side effects.
 
-To force a fresh token before a run and persist it to `.env`, use:
-
-```bash
-cargo run -- --fetch --fetch-username <username> --reauth
-```
-
-When a `.env` file is present, `--reauth` updates `X_BEARER_TOKEN` (or existing token keys) with the newly issued access token.
-
-## Common usage patterns
-
-```bash
-# fetch latest bookmarks and process them (user ID)
-cargo run -- --fetch --fetch-user-id <x_user_id>
-# fetch latest bookmarks and process them (username)
-cargo run -- --fetch --fetch-username joemccann
-# force token refresh before processing bookmarks
-cargo run -- --fetch --fetch-username joemccann --reauth
-
-# interactive browser reauth when the refresh token is invalid/expired
-# 1) Reauth flow will open your browser automatically
-cargo run -- --auth-url
-# 2) After authorization, exchange the code using the printed verifier
-cargo run -- --auth-code '<code>' --auth-code-verifier '<verifier>'
-
-If your app uses a different OAuth redirect URI:
-cargo run -- --auth-url --auth-redirect-uri 'http://localhost:8080/callback'
-
-# process bookmarks from JSON/text file
-cargo run -- --file path/to/bookmarks.json
-cargo run -- --text "ETH breakout after key support hold"
-
-# disable external side effects for dry-runs
+``` bash
 cargo run -- --no-save --no-cache --text "quick reasoning check"
 ```
 
-## Notes
+------------------------------------------------------------------------
 
-Python and Node runtime artifacts are intentionally out of the code path.
+# OAuth Reauth
+
+When the daemon's X API token expires, the pipeline starts an
+interactive OAuth 2.0 PKCE flow and listens for the callback on
+localhost. By default the user must click **Authorize app** in the
+browser manually.
+
+## Automatic consent via CDP (optional)
+
+Set `XPB_CHROME_USER_DATA_DIR` to a dedicated Chrome profile directory.
+When configured, the pipeline will:
+
+1.  Launch Chrome with `--remote-debugging-port=0` using that profile
+2.  Connect to Chrome DevTools Protocol via WebSocket
+3.  Locate the OAuth consent page and click **Authorize app** automatically
+4.  Fall back gracefully to manual mode if CDP is unavailable
+
+### One-time setup
+
+``` bash
+# Create a dedicated Chrome profile for OAuth
+mkdir -p ~/.chrome-oauth-profile
+
+# Add to .env
+echo 'XPB_CHROME_USER_DATA_DIR=/path/to/.chrome-oauth-profile' >> .env
+```
+
+The first time the reauth flow runs, Chrome will open with a fresh
+profile. Log into X once in that browser window. After that, all future
+OAuth reauths are fully automatic.
+
+### Failure modes
+
+All failures degrade cleanly to the existing manual flow:
+
+| Scenario | Behavior |
+|---|---|
+| `XPB_CHROME_USER_DATA_DIR` not set | Manual flow only (no regression) |
+| Chrome not launched with remote debugging | Log + manual fallback |
+| `DevToolsActivePort` missing or unreadable | Log + manual fallback |
+| User not logged into X | Log "login required", keep polling |
+| Consent button selector drift | Return manual fallback with diagnostics |
+| Callback arrives before CDP finishes | CDP task aborted cleanly |
+
+------------------------------------------------------------------------
+
+# Environment Variables
+
+## Required
+
+    CEREBRAS_API_KEY
+    XAI_API_KEY
+    ANTHROPIC_API_KEY
+    OPENAI_API_KEY
+
+## X API Authentication
+
+    X_BEARER_TOKEN          # or X_ACCESS_TOKEN
+    X_FETCH_USER_ID         # numeric user ID
+
+## OAuth Refresh (optional)
+
+    X_CLIENT_ID
+    X_CLIENT_SECRET
+    X_REFRESH_TOKEN
+    X_OAUTH_SCOPE
+
+## CDP Auto-Consent (optional)
+
+    XPB_CHROME_USER_DATA_DIR   # dedicated Chrome profile for reauth
+    XPB_CHROME_BINARY          # Chrome binary path override
+
+## Email Notifications (optional)
+
+    SMTP_HOST
+    SMTP_USER
+    SMTP_PASSWORD
+    SMTP_FROM
+    SMTP_TO
+
+## Runtime Configuration (optional)
+
+    CEREBRAS_MODEL
+    XAI_MODEL
+    ANTHROPIC_MODEL
+    OPENAI_MODEL
+
+    CACHE_PATH
+    MAX_WORKERS
+
+    API_TIMEOUT
+    VISION_TIMEOUT
+    FETCH_TIMEOUT
+
+    DEFAULT_TICKER
+    DEFAULT_TIMEFRAME
+
+## Daemon Configuration (optional)
+
+    XPB_DAEMON
+    XPB_DAEMON_INTERVAL_SECONDS
+    XPB_DAEMON_MAX_CYCLES
+    XPB_FETCH_LOOP
+
+------------------------------------------------------------------------
+
+# Dependencies
+
+Key Rust crates:
+
+| Crate | Purpose |
+|---|---|
+| `tokio` | Async runtime (multi-thread, networking, I/O) |
+| `reqwest` | HTTP client for LLM and X API calls |
+| `rusqlite` | SQLite caching (bundled) |
+| `serde` / `serde_json` | JSON serialization |
+| `clap` | CLI argument parsing |
+| `lettre` | SMTP email notifications |
+| `tokio-tungstenite` | WebSocket client for CDP auto-consent |
+| `futures-util` | Stream/sink combinators for WebSocket |
+| `anyhow` / `thiserror` | Error handling |
+
+See `Cargo.toml` for the full dependency list with versions.
+
+------------------------------------------------------------------------
+
+# Repository Structure
+
+    .
+    ├── src/
+    │   ├── main.rs           # Startup, CLI, OAuth flow
+    │   ├── orchestrator.rs   # Pipeline workflow
+    │   ├── llm.rs            # LLM provider abstraction
+    │   ├── cache.rs          # SQLite caching
+    │   ├── browser.rs        # CDP auto-consent client
+    │   ├── notify.rs         # SMTP notifications
+    │   ├── error.rs          # Structured pipeline errors
+    │   ├── classifier.rs     # Text/vision classification
+    │   ├── fetcher.rs        # X API bookmark fetcher
+    │   ├── generator.rs      # Pine Script generation
+    │   ├── planner.rs        # Strategy planning
+    │   ├── validator.rs      # Pine Script validation
+    │   ├── vision.rs         # Image analysis
+    │   └── ...
+    ├── Cargo.toml
+    ├── Cargo.lock
+    ├── .env.example
+    └── CLAUDE.md
+
+------------------------------------------------------------------------
+
+# Pipeline
+
+The pipeline executes the following stages:
+
+    Bookmarks
+      → Classification
+      → Vision Analysis
+      → Strategy Generation
+      → Script Validation
+      → Artifact Output
+
+Each stage is cached by bookmark id, allowing safe reruns without
+recomputation.
+
+------------------------------------------------------------------------
+
+# Architecture
+
+The system is implemented as a **single Rust crate**.
+
+Core modules:
+
+| Module | Purpose |
+|---|---|
+| `orchestrator.rs` | Pipeline workflow and concurrency |
+| `llm.rs` | LLM provider abstraction |
+| `cache.rs` | SQLite caching and migrations |
+| `browser.rs` | CDP WebSocket client for OAuth auto-consent |
+| `notify.rs` | SMTP notifications |
+| `error.rs` | Structured pipeline errors |
+
+The pipeline runs asynchronously with bounded worker concurrency.
+
+------------------------------------------------------------------------
+
+# Design Principles
+
+-   **Idempotent execution** --- safe to rerun any time
+-   **Deterministic artifacts** --- cached intermediate results
+-   **Parallel processing** --- high throughput
+-   **Provider abstraction** --- easy model switching
+-   **Graceful degradation** --- CDP auto-consent falls back to manual
+-   **Minimal runtime dependencies** --- Rust-only execution
+
+Python and Node runtimes are intentionally **not in the execution
+path**.

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1,0 +1,1086 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio::time::{sleep, Instant};
+use tokio_tungstenite::tungstenite::Message;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Configuration for the CDP auto-consent task.
+pub struct AutoConsentConfig {
+    /// The OAuth authorization URL that was opened in the browser.
+    /// Used to match the correct tab (by URL prefix or `state` parameter).
+    pub expected_auth_url: String,
+    /// Path to the Chrome user-data-dir whose `DevToolsActivePort` we read.
+    pub chrome_user_data_dir: PathBuf,
+    /// Maximum time to keep trying before giving up.
+    pub overall_timeout: Duration,
+    /// Delay between target-discovery polls.
+    pub poll_interval: Duration,
+}
+
+/// Structured outcome — better than a bool for logs and tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AutoConsentOutcome {
+    /// The consent button was clicked automatically.
+    Clicked { strategy: String },
+    /// Auto-consent is not available; user must click manually.
+    ManualFallback(&'static str),
+    /// Polling expired without finding or clicking the consent button.
+    TimedOut,
+}
+
+// ---------------------------------------------------------------------------
+// Target classification
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetKind {
+    Consent,
+    Login,
+    Callback,
+    Other,
+}
+
+pub fn classify_target(url: &str) -> TargetKind {
+    let lower = url.to_lowercase();
+    if lower.contains("/i/oauth2/authorize") {
+        TargetKind::Consent
+    } else if lower.contains("/i/flow/login")
+        || lower.contains("/login")
+            && (lower.contains("x.com") || lower.contains("twitter.com"))
+    {
+        TargetKind::Login
+    } else if lower.contains("localhost") && lower.contains("callback") {
+        TargetKind::Callback
+    } else {
+        TargetKind::Other
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DevToolsActivePort parsing
+// ---------------------------------------------------------------------------
+
+pub fn devtools_active_port_path(user_data_dir: &Path) -> PathBuf {
+    user_data_dir.join("DevToolsActivePort")
+}
+
+/// Parse the two-line DevToolsActivePort file.
+/// Line 1: port number (e.g. "9222")
+/// Line 2: browser websocket path (e.g. "/devtools/browser/abc-123")
+pub fn parse_devtools_active_port(contents: &str) -> Result<(u16, String)> {
+    let mut lines = contents.lines();
+    let port_line = lines
+        .next()
+        .filter(|l| !l.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("DevToolsActivePort: missing port line"))?;
+    let port: u16 = port_line
+        .trim()
+        .parse()
+        .context("DevToolsActivePort: invalid port number")?;
+    let ws_path = lines
+        .next()
+        .filter(|l| !l.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("DevToolsActivePort: missing websocket path line"))?
+        .trim()
+        .to_string();
+    Ok((port, ws_path))
+}
+
+pub fn build_ws_url(port: u16, browser_ws_path: &str) -> String {
+    format!("ws://127.0.0.1:{port}{browser_ws_path}")
+}
+
+// ---------------------------------------------------------------------------
+// Target discovery
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct TargetInfo {
+    pub target_id: String,
+    pub url: String,
+    pub kind: TargetKind,
+}
+
+/// Find the OAuth consent page target from `Target.getTargets` response.
+/// Requires `type == "page"` and URL matching the expected auth URL.
+/// Prefers exact URL prefix match; falls back to domain + path match.
+pub fn find_oauth_target(targets: &[Value], expected_auth_url: &str) -> Option<TargetInfo> {
+    // Extract the state param from expected URL for precise matching
+    let expected_state = extract_query_param(expected_auth_url, "state");
+
+    let mut best: Option<TargetInfo> = None;
+
+    for target in targets {
+        let target_type = target["type"].as_str().unwrap_or("");
+        if target_type != "page" {
+            continue;
+        }
+        let url = target["url"].as_str().unwrap_or("");
+        let target_id = target["targetId"].as_str().unwrap_or("");
+        let kind = classify_target(url);
+
+        if kind != TargetKind::Consent {
+            continue;
+        }
+
+        let info = TargetInfo {
+            target_id: target_id.to_string(),
+            url: url.to_string(),
+            kind,
+        };
+
+        // Prefer exact state match if we have one
+        if let Some(ref expected) = expected_state {
+            if let Some(actual) = extract_query_param(url, "state") {
+                if &actual == expected {
+                    return Some(info);
+                }
+            }
+        }
+
+        // Otherwise keep the first consent-page match
+        if best.is_none() {
+            best = Some(info);
+        }
+    }
+
+    best
+}
+
+fn extract_query_param(url: &str, key: &str) -> Option<String> {
+    let query = url.split('?').nth(1)?;
+    for pair in query.split('&') {
+        if let Some((k, v)) = pair.split_once('=') {
+            if k == key {
+                return Some(v.to_string());
+            }
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Click JavaScript
+// ---------------------------------------------------------------------------
+
+/// Returns an async IIFE that waits up to 5 seconds for the consent button,
+/// tries multiple selector strategies, and returns structured JSON.
+pub fn build_click_js() -> &'static str {
+    r#"(async function() {
+    function tryClick() {
+        // Strategy 1: data-testid (X's convention)
+        var btn = document.querySelector('[data-testid="OAuth_Consent_Button"]');
+        if (btn) { btn.click(); return {clicked:true, strategy:"data-testid", label:btn.textContent.trim().substring(0,80)}; }
+
+        // Strategy 2: button with "Authorize app" text
+        var buttons = Array.from(document.querySelectorAll('button'));
+        btn = buttons.find(function(b) { return /authorize\s*app/i.test(b.textContent); });
+        if (btn) { btn.click(); return {clicked:true, strategy:"text-authorize-app", label:btn.textContent.trim().substring(0,80)}; }
+
+        // Strategy 3: button with "Allow" text
+        btn = buttons.find(function(b) { return /^allow$/i.test(b.textContent.trim()); });
+        if (btn) { btn.click(); return {clicked:true, strategy:"text-allow", label:btn.textContent.trim().substring(0,80)}; }
+
+        // Strategy 4: sole submit button
+        var submits = Array.from(document.querySelectorAll('button[type="submit"]'));
+        if (submits.length === 1) { submits[0].click(); return {clicked:true, strategy:"sole-submit", label:submits[0].textContent.trim().substring(0,80)}; }
+
+        return {clicked:false, strategy:"none", label:""};
+    }
+
+    // Poll up to 5 seconds for the button to appear (React may still be rendering)
+    for (var i = 0; i < 25; i++) {
+        var result = tryClick();
+        if (result.clicked) return JSON.stringify(result);
+        await new Promise(function(r) { setTimeout(r, 200); });
+    }
+    return JSON.stringify({clicked:false, strategy:"none", label:""});
+})()"#
+}
+
+/// Parse the JSON string returned by the click JS.
+#[derive(Debug, Clone)]
+pub struct ClickResult {
+    pub clicked: bool,
+    pub strategy: String,
+    pub label: String,
+}
+
+pub fn parse_click_result(value: &str) -> ClickResult {
+    if let Ok(v) = serde_json::from_str::<Value>(value) {
+        ClickResult {
+            clicked: v["clicked"].as_bool().unwrap_or(false),
+            strategy: v["strategy"].as_str().unwrap_or("unknown").to_string(),
+            label: v["label"].as_str().unwrap_or("").to_string(),
+        }
+    } else {
+        ClickResult {
+            clicked: false,
+            strategy: "parse-error".to_string(),
+            label: String::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CDP WebSocket client
+// ---------------------------------------------------------------------------
+
+pub struct CdpClient {
+    sink: futures_util::stream::SplitSink<
+        tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+        Message,
+    >,
+    stream: futures_util::stream::SplitStream<
+        tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+    >,
+    next_id: AtomicU64,
+    cmd_timeout: Duration,
+}
+
+impl CdpClient {
+    pub async fn connect(url: &str) -> Result<Self> {
+        let (ws, _response) = tokio_tungstenite::connect_async(url)
+            .await
+            .context("CDP WebSocket connect failed")?;
+        let (sink, stream) = ws.split();
+        Ok(Self {
+            sink,
+            stream,
+            next_id: AtomicU64::new(1),
+            cmd_timeout: Duration::from_secs(5),
+        })
+    }
+
+    /// Send a CDP command (browser-level, no session).
+    pub async fn send(&mut self, method: &str, params: Value) -> Result<Value> {
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let msg = json!({ "id": id, "method": method, "params": params });
+        self.sink
+            .send(Message::Text(msg.to_string().into()))
+            .await
+            .context("CDP send failed")?;
+        self.read_response(id).await
+    }
+
+    /// Send a CDP command scoped to a flat session.
+    pub async fn send_to_session(
+        &mut self,
+        session_id: &str,
+        method: &str,
+        params: Value,
+    ) -> Result<Value> {
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let msg = json!({
+            "id": id,
+            "method": method,
+            "params": params,
+            "sessionId": session_id,
+        });
+        self.sink
+            .send(Message::Text(msg.to_string().into()))
+            .await
+            .context("CDP send_to_session failed")?;
+        self.read_response(id).await
+    }
+
+    /// Read messages until we find the response matching `expected_id`.
+    /// Discards CDP event messages (no `id` field) along the way.
+    async fn read_response(&mut self, expected_id: u64) -> Result<Value> {
+        let deadline = Instant::now() + self.cmd_timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(anyhow::anyhow!(
+                    "CDP response timeout for message id {expected_id}"
+                ));
+            }
+            let msg = tokio::time::timeout(remaining, self.stream.next())
+                .await
+                .map_err(|_| anyhow::anyhow!("CDP response timeout for message id {expected_id}"))?
+                .ok_or_else(|| anyhow::anyhow!("CDP WebSocket stream ended"))?
+                .context("CDP WebSocket read error")?;
+
+            if let Message::Text(text) = msg {
+                let value: Value =
+                    serde_json::from_str(&text).context("CDP response is not valid JSON")?;
+                // Check if this is a response (has `id`) matching ours
+                if let Some(id) = value.get("id").and_then(Value::as_u64) {
+                    if id == expected_id {
+                        if let Some(error) = value.get("error") {
+                            return Err(anyhow::anyhow!("CDP error: {}", error));
+                        }
+                        return Ok(value);
+                    }
+                }
+                // Otherwise it's an event or someone else's response — discard
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Attempt to auto-click the OAuth consent button in Chrome via CDP.
+///
+/// This function is designed to run concurrently with `wait_for_oauth_code`.
+/// It connects to Chrome's DevTools WebSocket, finds the OAuth consent page,
+/// and clicks the "Authorize app" button. If anything fails, it returns
+/// a structured outcome explaining why, never panicking or blocking.
+pub async fn auto_click_oauth_consent(cfg: AutoConsentConfig) -> Result<AutoConsentOutcome> {
+    let port_path = devtools_active_port_path(&cfg.chrome_user_data_dir);
+    let deadline = Instant::now() + cfg.overall_timeout;
+
+    // Phase 1: Wait for DevToolsActivePort to appear
+    let (port, ws_path) = loop {
+        if Instant::now() >= deadline {
+            return Ok(AutoConsentOutcome::ManualFallback(
+                "DevToolsActivePort never appeared before deadline",
+            ));
+        }
+        match tokio::fs::read_to_string(&port_path).await {
+            Ok(contents) => match parse_devtools_active_port(&contents) {
+                Ok(parsed) => break parsed,
+                Err(e) => {
+                    eprintln!("[cdp] DevToolsActivePort parse error: {e}");
+                    sleep(cfg.poll_interval).await;
+                }
+            },
+            Err(_) => {
+                sleep(cfg.poll_interval).await;
+            }
+        }
+    };
+
+    let ws_url = build_ws_url(port, &ws_path);
+    let mut client = match CdpClient::connect(&ws_url).await {
+        Ok(c) => c,
+        Err(e) => {
+            return Ok(AutoConsentOutcome::ManualFallback(
+                if e.to_string().contains("Connection refused") {
+                    "Chrome remote debugging not enabled (connection refused)"
+                } else {
+                    "CDP WebSocket connection failed"
+                },
+            ));
+        }
+    };
+
+    // Phase 2: Poll for the OAuth consent tab
+    let mut retry_count = 0u32;
+    let mut saw_login = false;
+
+    loop {
+        if Instant::now() >= deadline {
+            return Ok(AutoConsentOutcome::TimedOut);
+        }
+        retry_count += 1;
+
+        let targets_resp = match client.send("Target.getTargets", json!({})).await {
+            Ok(resp) => resp,
+            Err(e) => {
+                eprintln!("[cdp] Target.getTargets failed: {e}");
+                sleep(cfg.poll_interval).await;
+                continue;
+            }
+        };
+
+        let targets = targets_resp
+            .get("result")
+            .and_then(|r| r.get("targetInfos"))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+
+        // Check for login pages (log once, keep polling)
+        if !saw_login {
+            for t in &targets {
+                let url = t["url"].as_str().unwrap_or("");
+                if classify_target(url) == TargetKind::Login {
+                    eprintln!("[cdp] X login page detected — waiting for user to log in");
+                    saw_login = true;
+                    break;
+                }
+            }
+        }
+
+        // Look for the consent page
+        if let Some(target) = find_oauth_target(&targets, &cfg.expected_auth_url) {
+            // Optionally activate the tab
+            let _ = client
+                .send(
+                    "Target.activateTarget",
+                    json!({ "targetId": target.target_id }),
+                )
+                .await;
+
+            // Attach to the target with flat session
+            let attach_resp = match client
+                .send(
+                    "Target.attachToTarget",
+                    json!({ "targetId": target.target_id, "flatten": true }),
+                )
+                .await
+            {
+                Ok(resp) => resp,
+                Err(e) => {
+                    eprintln!("[cdp] attachToTarget failed: {e} (retry {retry_count})");
+                    sleep(cfg.poll_interval).await;
+                    continue;
+                }
+            };
+
+            let session_id = match attach_resp
+                .get("result")
+                .and_then(|r| r.get("sessionId"))
+                .and_then(Value::as_str)
+            {
+                Some(sid) => sid.to_string(),
+                None => {
+                    eprintln!("[cdp] attachToTarget returned no sessionId (retry {retry_count})");
+                    sleep(cfg.poll_interval).await;
+                    continue;
+                }
+            };
+
+            // Execute the click JS with userGesture and awaitPromise
+            let eval_resp = match client
+                .send_to_session(
+                    &session_id,
+                    "Runtime.evaluate",
+                    json!({
+                        "expression": build_click_js(),
+                        "returnByValue": true,
+                        "awaitPromise": true,
+                        "userGesture": true,
+                        "timeout": 5000,
+                    }),
+                )
+                .await
+            {
+                Ok(resp) => resp,
+                Err(e) => {
+                    eprintln!("[cdp] Runtime.evaluate failed: {e} (retry {retry_count})");
+                    // Detach session and retry
+                    sleep(cfg.poll_interval).await;
+                    continue;
+                }
+            };
+
+            // Parse the result
+            let result_str = eval_resp
+                .get("result")
+                .and_then(|r| r.get("result"))
+                .and_then(|r| r.get("value"))
+                .and_then(Value::as_str)
+                .unwrap_or("");
+
+            let click_result = parse_click_result(result_str);
+
+            if click_result.clicked {
+                eprintln!(
+                    "[cdp] consent button clicked via {} ({}) after {} polls",
+                    click_result.strategy,
+                    click_result.label,
+                    retry_count,
+                );
+                return Ok(AutoConsentOutcome::Clicked {
+                    strategy: click_result.strategy,
+                });
+            }
+
+            // Button not found yet — page may still be rendering
+            eprintln!("[cdp] consent button not found yet (retry {retry_count})");
+        }
+
+        sleep(cfg.poll_interval).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Bind a tokio TcpListener on an OS-assigned port and return (listener, port).
+    async fn bind_test_server() -> (tokio::net::TcpListener, u16) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        (listener, port)
+    }
+
+    // ── Unit tests: DevToolsActivePort parsing ──
+
+    #[test]
+    fn parse_devtools_active_port_valid_returns_port_and_path() {
+        let input = "9222\n/devtools/browser/abc-def-123\n";
+        let (port, path) = parse_devtools_active_port(input).unwrap();
+        assert_eq!(port, 9222);
+        assert_eq!(path, "/devtools/browser/abc-def-123");
+    }
+
+    #[test]
+    fn parse_devtools_active_port_empty_errors() {
+        assert!(parse_devtools_active_port("").is_err());
+    }
+
+    #[test]
+    fn parse_devtools_active_port_missing_second_line_errors() {
+        assert!(parse_devtools_active_port("9222\n").is_err());
+    }
+
+    #[test]
+    fn parse_devtools_active_port_non_numeric_port_errors() {
+        assert!(parse_devtools_active_port("notaport\n/devtools/browser/abc\n").is_err());
+    }
+
+    #[test]
+    fn parse_devtools_active_port_whitespace_trimmed() {
+        let input = " 9222 \n /devtools/browser/xyz \n";
+        let (port, path) = parse_devtools_active_port(input).unwrap();
+        assert_eq!(port, 9222);
+        assert_eq!(path, "/devtools/browser/xyz");
+    }
+
+    // ── Unit tests: WebSocket URL construction ──
+
+    #[test]
+    fn build_ws_url_formats_correctly() {
+        assert_eq!(
+            build_ws_url(9222, "/devtools/browser/abc-123"),
+            "ws://127.0.0.1:9222/devtools/browser/abc-123"
+        );
+    }
+
+    #[test]
+    fn build_ws_url_different_port() {
+        assert_eq!(
+            build_ws_url(41323, "/devtools/browser/xyz"),
+            "ws://127.0.0.1:41323/devtools/browser/xyz"
+        );
+    }
+
+    // ── Unit tests: DevToolsActivePort path derivation ──
+
+    #[test]
+    fn devtools_active_port_path_derives_from_user_data_dir() {
+        let dir = Path::new("/tmp/chrome-oauth-profile");
+        let path = devtools_active_port_path(dir);
+        assert_eq!(path, PathBuf::from("/tmp/chrome-oauth-profile/DevToolsActivePort"));
+    }
+
+    // ── Unit tests: target classification ──
+
+    #[test]
+    fn classify_target_detects_consent_urls() {
+        assert_eq!(
+            classify_target("https://x.com/i/oauth2/authorize?client_id=abc&state=xyz"),
+            TargetKind::Consent
+        );
+        assert_eq!(
+            classify_target("https://twitter.com/i/oauth2/authorize?foo=bar"),
+            TargetKind::Consent
+        );
+    }
+
+    #[test]
+    fn classify_target_detects_login_urls() {
+        assert_eq!(
+            classify_target("https://x.com/i/flow/login?redirect_after_login=..."),
+            TargetKind::Login
+        );
+        assert_eq!(
+            classify_target("https://x.com/login"),
+            TargetKind::Login
+        );
+    }
+
+    #[test]
+    fn classify_target_detects_callback_urls() {
+        assert_eq!(
+            classify_target("http://localhost:8080/callback?code=abc&state=xyz"),
+            TargetKind::Callback
+        );
+    }
+
+    #[test]
+    fn classify_target_returns_other_for_normal_pages() {
+        assert_eq!(
+            classify_target("https://x.com/home"),
+            TargetKind::Other
+        );
+        assert_eq!(
+            classify_target("https://google.com"),
+            TargetKind::Other
+        );
+    }
+
+    // ── Unit tests: target discovery ──
+
+    #[test]
+    fn find_oauth_target_matches_exact_authorize_url() {
+        let targets = vec![
+            json!({"type": "page", "targetId": "t1", "url": "https://x.com/home"}),
+            json!({"type": "page", "targetId": "t2", "url": "https://x.com/i/oauth2/authorize?client_id=abc&state=expected123"}),
+        ];
+        let found = find_oauth_target(
+            &targets,
+            "https://x.com/i/oauth2/authorize?client_id=abc&state=expected123",
+        );
+        assert!(found.is_some());
+        let info = found.unwrap();
+        assert_eq!(info.target_id, "t2");
+        assert_eq!(info.kind, TargetKind::Consent);
+    }
+
+    #[test]
+    fn find_oauth_target_prefers_state_match() {
+        let targets = vec![
+            json!({"type": "page", "targetId": "old", "url": "https://x.com/i/oauth2/authorize?state=stale"}),
+            json!({"type": "page", "targetId": "current", "url": "https://x.com/i/oauth2/authorize?state=fresh"}),
+        ];
+        let found = find_oauth_target(
+            &targets,
+            "https://x.com/i/oauth2/authorize?state=fresh",
+        );
+        assert_eq!(found.unwrap().target_id, "current");
+    }
+
+    #[test]
+    fn find_oauth_target_ignores_non_page_targets() {
+        let targets = vec![
+            json!({"type": "background_page", "targetId": "t1", "url": "https://x.com/i/oauth2/authorize?state=abc"}),
+            json!({"type": "service_worker", "targetId": "t2", "url": "https://x.com/i/oauth2/authorize?state=abc"}),
+        ];
+        assert!(find_oauth_target(&targets, "https://x.com/i/oauth2/authorize?state=abc").is_none());
+    }
+
+    #[test]
+    fn find_oauth_target_returns_none_when_absent() {
+        let targets = vec![
+            json!({"type": "page", "targetId": "t1", "url": "https://x.com/home"}),
+            json!({"type": "page", "targetId": "t2", "url": "https://google.com"}),
+        ];
+        assert!(find_oauth_target(&targets, "https://x.com/i/oauth2/authorize?state=abc").is_none());
+    }
+
+    // ── Unit tests: click JS ──
+
+    #[test]
+    fn build_click_js_contains_wait_logic_and_structured_return() {
+        let js = build_click_js();
+        // Must be an async IIFE
+        assert!(js.contains("async function()"));
+        // Must wait for DOM with setTimeout polling
+        assert!(js.contains("setTimeout"));
+        // Must try data-testid strategy
+        assert!(js.contains("OAuth_Consent_Button"));
+        // Must try text strategies
+        assert!(js.contains("authorize"));
+        assert!(js.contains("allow"));
+        // Must return structured JSON
+        assert!(js.contains("JSON.stringify"));
+        assert!(js.contains("clicked"));
+        assert!(js.contains("strategy"));
+    }
+
+    // ── Unit tests: click result parsing ──
+
+    #[test]
+    fn parse_click_result_valid_clicked() {
+        let result = parse_click_result(r#"{"clicked":true,"strategy":"data-testid","label":"Authorize app"}"#);
+        assert!(result.clicked);
+        assert_eq!(result.strategy, "data-testid");
+        assert_eq!(result.label, "Authorize app");
+    }
+
+    #[test]
+    fn parse_click_result_not_found() {
+        let result = parse_click_result(r#"{"clicked":false,"strategy":"none","label":""}"#);
+        assert!(!result.clicked);
+        assert_eq!(result.strategy, "none");
+    }
+
+    #[test]
+    fn parse_click_result_invalid_json() {
+        let result = parse_click_result("not json at all");
+        assert!(!result.clicked);
+        assert_eq!(result.strategy, "parse-error");
+    }
+
+    // ── Unit tests: query param extraction ──
+
+    #[test]
+    fn extract_query_param_finds_state() {
+        let url = "https://x.com/i/oauth2/authorize?client_id=abc&state=xyz123&scope=read";
+        assert_eq!(extract_query_param(url, "state"), Some("xyz123".to_string()));
+        assert_eq!(extract_query_param(url, "client_id"), Some("abc".to_string()));
+        assert_eq!(extract_query_param(url, "missing"), None);
+    }
+
+    // ── Integration tests: CDP message correlation ──
+
+    #[tokio::test]
+    async fn cdp_client_correlates_response_ids_while_ignoring_events() {
+        let (listener, port) = bind_test_server().await;
+        let ws_url = format!("ws://127.0.0.1:{port}");
+
+        let server_handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+            // Read the client's request
+            let msg = ws.next().await.unwrap().unwrap();
+            let req: Value = serde_json::from_str(&msg.into_text().unwrap()).unwrap();
+            let req_id = req["id"].as_u64().unwrap();
+
+            // Send an unsolicited event first (should be ignored by client)
+            let event = json!({"method": "Target.targetCreated", "params": {"targetInfo": {}}});
+            ws.send(Message::Text(event.to_string().into())).await.unwrap();
+
+            // Then send the actual response
+            let resp = json!({"id": req_id, "result": {"targetInfos": []}});
+            ws.send(Message::Text(resp.to_string().into())).await.unwrap();
+        });
+
+        // Give server a moment to bind
+        sleep(Duration::from_millis(50)).await;
+
+        let mut client = CdpClient::connect(&ws_url).await.unwrap();
+        let resp = client.send("Target.getTargets", json!({})).await.unwrap();
+
+        // Should have received the response, ignoring the event
+        assert!(resp["result"]["targetInfos"].is_array());
+
+        server_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn send_to_session_includes_session_id() {
+        let (listener, port) = bind_test_server().await;
+        let ws_url = format!("ws://127.0.0.1:{port}");
+
+        let server_handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+            let msg = ws.next().await.unwrap().unwrap();
+            let req: Value = serde_json::from_str(&msg.into_text().unwrap()).unwrap();
+
+            // Verify the sessionId was included in the request
+            assert_eq!(req["sessionId"].as_str().unwrap(), "session-abc-123");
+            assert_eq!(req["method"].as_str().unwrap(), "Runtime.evaluate");
+
+            let resp = json!({"id": req["id"].as_u64().unwrap(), "result": {"result": {"value": "ok"}}});
+            ws.send(Message::Text(resp.to_string().into())).await.unwrap();
+        });
+
+        sleep(Duration::from_millis(50)).await;
+
+        let mut client = CdpClient::connect(&ws_url).await.unwrap();
+        let resp = client
+            .send_to_session("session-abc-123", "Runtime.evaluate", json!({"expression": "1+1"}))
+            .await
+            .unwrap();
+        assert!(resp.get("result").is_some());
+
+        server_handle.await.unwrap();
+    }
+
+    // ── Integration tests: full auto-consent flow with fake CDP server ──
+
+    #[tokio::test]
+    async fn happy_path_get_targets_attach_evaluate_clicked() {
+        let (listener, port) = bind_test_server().await;
+
+        let tmp_dir = std::env::temp_dir().join(format!("cdp-test-happy-{}", port));
+        let _ = tokio::fs::create_dir_all(&tmp_dir).await;
+        let port_file = tmp_dir.join("DevToolsActivePort");
+        tokio::fs::write(&port_file, format!("{port}\n/devtools/browser/fake\n"))
+            .await
+            .unwrap();
+
+        let server_handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+            // 1. Target.getTargets
+            let msg = ws.next().await.unwrap().unwrap();
+            let req: Value = serde_json::from_str(&msg.into_text().unwrap()).unwrap();
+            let resp = json!({
+                "id": req["id"],
+                "result": {
+                    "targetInfos": [{
+                        "type": "page",
+                        "targetId": "target-1",
+                        "url": "https://x.com/i/oauth2/authorize?state=test123"
+                    }]
+                }
+            });
+            ws.send(Message::Text(resp.to_string().into())).await.unwrap();
+
+            // 2. Target.activateTarget
+            let msg = ws.next().await.unwrap().unwrap();
+            let req: Value = serde_json::from_str(&msg.into_text().unwrap()).unwrap();
+            ws.send(Message::Text(json!({"id": req["id"], "result": {}}).to_string().into()))
+                .await
+                .unwrap();
+
+            // 3. Target.attachToTarget
+            let msg = ws.next().await.unwrap().unwrap();
+            let req: Value = serde_json::from_str(&msg.into_text().unwrap()).unwrap();
+            assert_eq!(req["params"]["flatten"], true);
+            let resp = json!({"id": req["id"], "result": {"sessionId": "sess-1"}});
+            ws.send(Message::Text(resp.to_string().into())).await.unwrap();
+
+            // 4. Runtime.evaluate
+            let msg = ws.next().await.unwrap().unwrap();
+            let req: Value = serde_json::from_str(&msg.into_text().unwrap()).unwrap();
+            assert_eq!(req["sessionId"], "sess-1");
+            assert_eq!(req["params"]["userGesture"], true);
+            assert_eq!(req["params"]["awaitPromise"], true);
+            let resp = json!({
+                "id": req["id"],
+                "result": {
+                    "result": {
+                        "value": r#"{"clicked":true,"strategy":"data-testid","label":"Authorize app"}"#
+                    }
+                }
+            });
+            ws.send(Message::Text(resp.to_string().into())).await.unwrap();
+        });
+
+        let cfg = AutoConsentConfig {
+            expected_auth_url: "https://x.com/i/oauth2/authorize?state=test123".to_string(),
+            chrome_user_data_dir: tmp_dir.clone(),
+            overall_timeout: Duration::from_secs(10),
+            poll_interval: Duration::from_millis(100),
+        };
+
+        let outcome = auto_click_oauth_consent(cfg).await.unwrap();
+        assert_eq!(
+            outcome,
+            AutoConsentOutcome::Clicked {
+                strategy: "data-testid".to_string()
+            }
+        );
+
+        server_handle.await.unwrap();
+        let _ = tokio::fs::remove_dir_all(&tmp_dir).await;
+    }
+
+    #[tokio::test]
+    async fn login_page_first_then_consent_page_later() {
+        let (listener, port) = bind_test_server().await;
+
+        let tmp_dir = std::env::temp_dir().join(format!("cdp-test-login-{}", port));
+        let _ = tokio::fs::create_dir_all(&tmp_dir).await;
+        tokio::fs::write(
+            tmp_dir.join("DevToolsActivePort"),
+            format!("{port}\n/devtools/browser/fake\n"),
+        )
+        .await
+        .unwrap();
+
+        let server_handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+            // Poll 1: login page only
+            let msg = ws.next().await.unwrap().unwrap();
+            let req: Value = serde_json::from_str(&msg.into_text().unwrap()).unwrap();
+            ws.send(Message::Text(json!({
+                "id": req["id"],
+                "result": {"targetInfos": [
+                    {"type": "page", "targetId": "t1", "url": "https://x.com/i/flow/login"}
+                ]}
+            }).to_string().into())).await.unwrap();
+
+            // Poll 2: consent page appears
+            let msg = ws.next().await.unwrap().unwrap();
+            let req: Value = serde_json::from_str(&msg.into_text().unwrap()).unwrap();
+            ws.send(Message::Text(json!({
+                "id": req["id"],
+                "result": {"targetInfos": [
+                    {"type": "page", "targetId": "t2", "url": "https://x.com/i/oauth2/authorize?state=abc"}
+                ]}
+            }).to_string().into())).await.unwrap();
+
+            // activateTarget
+            let msg = ws.next().await.unwrap().unwrap();
+            let req: Value = serde_json::from_str(&msg.into_text().unwrap()).unwrap();
+            ws.send(Message::Text(json!({"id": req["id"], "result": {}}).to_string().into()))
+                .await.unwrap();
+
+            // attachToTarget
+            let msg = ws.next().await.unwrap().unwrap();
+            let req: Value = serde_json::from_str(&msg.into_text().unwrap()).unwrap();
+            ws.send(Message::Text(json!({"id": req["id"], "result": {"sessionId": "s1"}}).to_string().into()))
+                .await.unwrap();
+
+            // Runtime.evaluate
+            let msg = ws.next().await.unwrap().unwrap();
+            let req: Value = serde_json::from_str(&msg.into_text().unwrap()).unwrap();
+            ws.send(Message::Text(json!({
+                "id": req["id"],
+                "result": {"result": {"value": r#"{"clicked":true,"strategy":"text-authorize-app","label":"Authorize app"}"#}}
+            }).to_string().into())).await.unwrap();
+        });
+
+        let cfg = AutoConsentConfig {
+            expected_auth_url: "https://x.com/i/oauth2/authorize?state=abc".to_string(),
+            chrome_user_data_dir: tmp_dir.clone(),
+            overall_timeout: Duration::from_secs(10),
+            poll_interval: Duration::from_millis(100),
+        };
+
+        let outcome = auto_click_oauth_consent(cfg).await.unwrap();
+        assert!(matches!(outcome, AutoConsentOutcome::Clicked { .. }));
+
+        server_handle.await.unwrap();
+        let _ = tokio::fs::remove_dir_all(&tmp_dir).await;
+    }
+
+    #[tokio::test]
+    async fn devtools_active_port_missing_returns_manual_fallback() {
+        let tmp_dir = std::env::temp_dir().join("cdp-test-missing-port");
+        let _ = tokio::fs::create_dir_all(&tmp_dir).await;
+        // Intentionally do NOT write a DevToolsActivePort file
+
+        let cfg = AutoConsentConfig {
+            expected_auth_url: "https://x.com/i/oauth2/authorize?state=abc".to_string(),
+            chrome_user_data_dir: tmp_dir.clone(),
+            overall_timeout: Duration::from_millis(500),
+            poll_interval: Duration::from_millis(100),
+        };
+
+        let outcome = auto_click_oauth_consent(cfg).await.unwrap();
+        assert_eq!(
+            outcome,
+            AutoConsentOutcome::ManualFallback("DevToolsActivePort never appeared before deadline")
+        );
+
+        let _ = tokio::fs::remove_dir_all(&tmp_dir).await;
+    }
+
+    #[tokio::test]
+    async fn no_matching_target_before_deadline_returns_timeout() {
+        let (listener, port) = bind_test_server().await;
+
+        let tmp_dir = std::env::temp_dir().join(format!("cdp-test-timeout-{}", port));
+        let _ = tokio::fs::create_dir_all(&tmp_dir).await;
+        tokio::fs::write(
+            tmp_dir.join("DevToolsActivePort"),
+            format!("{port}\n/devtools/browser/fake\n"),
+        )
+        .await
+        .unwrap();
+
+        let server_handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+            // Keep returning empty targets until client gives up
+            loop {
+                let msg = ws.next().await;
+                match msg {
+                    Some(Ok(Message::Text(text))) => {
+                        let req: Value = serde_json::from_str(&text).unwrap();
+                        ws.send(Message::Text(json!({
+                            "id": req["id"],
+                            "result": {"targetInfos": [
+                                {"type": "page", "targetId": "t1", "url": "https://x.com/home"}
+                            ]}
+                        }).to_string().into())).await.unwrap();
+                    }
+                    _ => break,
+                }
+            }
+        });
+
+        let cfg = AutoConsentConfig {
+            expected_auth_url: "https://x.com/i/oauth2/authorize?state=abc".to_string(),
+            chrome_user_data_dir: tmp_dir.clone(),
+            overall_timeout: Duration::from_millis(800),
+            poll_interval: Duration::from_millis(100),
+        };
+
+        let outcome = auto_click_oauth_consent(cfg).await.unwrap();
+        assert_eq!(outcome, AutoConsentOutcome::TimedOut);
+
+        server_handle.abort();
+        let _ = tokio::fs::remove_dir_all(&tmp_dir).await;
+    }
+
+    #[tokio::test]
+    async fn cancellation_after_callback_task_exits_cleanly() {
+        let (listener, port) = bind_test_server().await;
+
+        let tmp_dir = std::env::temp_dir().join(format!("cdp-test-cancel-{}", port));
+        let _ = tokio::fs::create_dir_all(&tmp_dir).await;
+        tokio::fs::write(
+            tmp_dir.join("DevToolsActivePort"),
+            format!("{port}\n/devtools/browser/fake\n"),
+        )
+        .await
+        .unwrap();
+
+        let server_handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+            // Respond slowly — keep returning empty targets
+            loop {
+                let msg = ws.next().await;
+                match msg {
+                    Some(Ok(Message::Text(text))) => {
+                        let req: Value = serde_json::from_str(&text).unwrap();
+                        ws.send(Message::Text(json!({
+                            "id": req["id"],
+                            "result": {"targetInfos": []}
+                        }).to_string().into())).await.unwrap();
+                    }
+                    _ => break,
+                }
+            }
+        });
+
+        let cfg = AutoConsentConfig {
+            expected_auth_url: "https://x.com/i/oauth2/authorize?state=abc".to_string(),
+            chrome_user_data_dir: tmp_dir.clone(),
+            overall_timeout: Duration::from_secs(30),
+            poll_interval: Duration::from_millis(100),
+        };
+
+        // Spawn the auto-consent task
+        let handle = tokio::spawn(auto_click_oauth_consent(cfg));
+
+        // Simulate: callback arrives after 300ms, abort the CDP task
+        sleep(Duration::from_millis(300)).await;
+        handle.abort();
+
+        // The abort should not panic
+        let result = handle.await;
+        assert!(result.is_err()); // JoinError::Cancelled
+
+        server_handle.abort();
+        let _ = tokio::fs::remove_dir_all(&tmp_dir).await;
+    }
+}

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -1,0 +1,456 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// Token usage from a single LLM API call.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UsageInfo {
+    pub provider: String,
+    pub model: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+impl UsageInfo {
+    pub fn total_tokens(&self) -> u64 {
+        self.input_tokens + self.output_tokens
+    }
+}
+
+/// Per-model pricing in USD per 1M tokens: (input, output).
+/// Updated 2026-03. Conservative estimates; actual pricing may vary.
+fn price_per_million(provider: &str, model: &str) -> (f64, f64) {
+    match provider {
+        "cerebras" => {
+            if model.contains("qwen-3-235b") {
+                (0.20, 0.20) // Cerebras inference pricing
+            } else {
+                (0.10, 0.10)
+            }
+        }
+        "xai" => {
+            if model.contains("grok-4") {
+                (3.00, 15.00) // xAI Grok-4 pricing
+            } else if model.contains("grok-3") {
+                (3.00, 15.00)
+            } else {
+                (2.00, 10.00)
+            }
+        }
+        "claude" => {
+            if model.contains("opus") {
+                (15.00, 75.00) // Claude Opus
+            } else if model.contains("sonnet") {
+                (3.00, 15.00) // Claude Sonnet
+            } else if model.contains("haiku") {
+                (0.25, 1.25) // Claude Haiku
+            } else {
+                (15.00, 75.00) // default to Opus pricing
+            }
+        }
+        "openai" => {
+            if model.contains("gpt-5") {
+                (2.00, 8.00) // GPT-5 estimated
+            } else if model.contains("gpt-4") || model.contains("o3") || model.contains("o4") {
+                (2.50, 10.00) // GPT-4o/o3
+            } else {
+                (2.00, 8.00)
+            }
+        }
+        _ => (1.00, 4.00), // fallback
+    }
+}
+
+/// Compute the USD cost for a single API call.
+pub fn compute_cost(usage: &UsageInfo) -> f64 {
+    let (input_rate, output_rate) = price_per_million(&usage.provider, &usage.model);
+    let input_cost = usage.input_tokens as f64 * input_rate / 1_000_000.0;
+    let output_cost = usage.output_tokens as f64 * output_rate / 1_000_000.0;
+    input_cost + output_cost
+}
+
+/// A single cost entry for one LLM call within a bookmark's pipeline run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CostEntry {
+    pub bookmark_id: String,
+    pub stage: String,
+    pub provider: String,
+    pub model: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cost_usd: f64,
+}
+
+/// Accumulates cost entries across pipeline stages for all bookmarks.
+#[derive(Debug, Clone)]
+pub struct CostTracker {
+    entries: Arc<Mutex<Vec<CostEntry>>>,
+    active_bookmark: Arc<Mutex<String>>,
+}
+
+impl CostTracker {
+    pub fn new() -> Self {
+        Self {
+            entries: Arc::new(Mutex::new(Vec::new())),
+            active_bookmark: Arc::new(Mutex::new(String::new())),
+        }
+    }
+
+    pub fn record(&self, bookmark_id: &str, stage: &str, usage: &UsageInfo) {
+        let cost = compute_cost(usage);
+        let entry = CostEntry {
+            bookmark_id: bookmark_id.to_string(),
+            stage: stage.to_string(),
+            provider: usage.provider.clone(),
+            model: usage.model.clone(),
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            cost_usd: cost,
+        };
+        self.entries.lock().unwrap().push(entry);
+    }
+
+    /// Set the active bookmark ID context for recording.
+    /// This is used by providers that don't know which bookmark they're processing.
+    pub fn set_active_bookmark(&self, bookmark_id: &str) {
+        *self.active_bookmark.lock().unwrap() = bookmark_id.to_string();
+    }
+
+    /// Record usage with the currently active bookmark context.
+    pub fn record_active(&self, stage: &str, usage: &UsageInfo) {
+        let bookmark_id = self.active_bookmark.lock().unwrap().clone();
+        self.record(&bookmark_id, stage, usage);
+    }
+
+    pub fn entries(&self) -> Vec<CostEntry> {
+        self.entries.lock().unwrap().clone()
+    }
+
+    pub fn total_cost(&self) -> f64 {
+        self.entries.lock().unwrap().iter().map(|e| e.cost_usd).sum()
+    }
+
+    pub fn to_json(&self) -> serde_json::Value {
+        let entries = self.entries();
+        let total: f64 = entries.iter().map(|e| e.cost_usd).sum();
+        let total_input: u64 = entries.iter().map(|e| e.input_tokens).sum();
+        let total_output: u64 = entries.iter().map(|e| e.output_tokens).sum();
+
+        serde_json::json!({
+            "total_cost_usd": format!("{:.6}", total),
+            "total_input_tokens": total_input,
+            "total_output_tokens": total_output,
+            "calls": entries,
+        })
+    }
+}
+
+/// Summary of costs across all bookmarks in a pipeline run, for reporting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunCostSummary {
+    pub bookmark_id: String,
+    pub category: String,
+    pub is_finance: bool,
+    pub total_cost_usd: f64,
+    pub entries: Vec<CostEntry>,
+}
+
+/// Generate a markdown cost report from per-bookmark summaries.
+pub fn generate_cost_report(summaries: &[RunCostSummary]) -> String {
+    let mut md = String::new();
+    md.push_str("# LLM Cost Report\n\n");
+    md.push_str(&format!(
+        "Generated: {}\n\n",
+        chrono_now()
+    ));
+
+    // YTD summary by provider
+    let mut by_provider: HashMap<String, (u64, u64, f64)> = HashMap::new();
+    let mut grand_total = 0.0f64;
+
+    for summary in summaries {
+        grand_total += summary.total_cost_usd;
+        for entry in &summary.entries {
+            let e = by_provider.entry(entry.provider.clone()).or_default();
+            e.0 += entry.input_tokens;
+            e.1 += entry.output_tokens;
+            e.2 += entry.cost_usd;
+        }
+    }
+
+    md.push_str("## Summary\n\n");
+    md.push_str(&format!(
+        "- **Total bookmarks processed**: {}\n",
+        summaries.len()
+    ));
+    md.push_str(&format!(
+        "- **Total LLM cost**: ${:.4}\n\n",
+        grand_total
+    ));
+
+    // Provider breakdown
+    md.push_str("## Cost by Provider\n\n");
+    md.push_str("| Provider | Input Tokens | Output Tokens | Cost (USD) | % of Total |\n");
+    md.push_str("|----------|-------------|---------------|-----------|------------|\n");
+
+    let mut providers: Vec<_> = by_provider.iter().collect();
+    providers.sort_by(|a, b| b.1 .2.partial_cmp(&a.1 .2).unwrap());
+
+    for (provider, (input, output, cost)) in &providers {
+        let pct = if grand_total > 0.0 {
+            cost / grand_total * 100.0
+        } else {
+            0.0
+        };
+        md.push_str(&format!(
+            "| {} | {:>11} | {:>13} | ${:>8.4} | {:>9.1}% |\n",
+            provider, input, output, cost, pct
+        ));
+    }
+    md.push('\n');
+
+    // Cost by stage
+    let mut by_stage: HashMap<String, f64> = HashMap::new();
+    for summary in summaries {
+        for entry in &summary.entries {
+            *by_stage.entry(entry.stage.clone()).or_default() += entry.cost_usd;
+        }
+    }
+
+    md.push_str("## Cost by Pipeline Stage\n\n");
+    md.push_str("| Stage | Cost (USD) | % of Total |\n");
+    md.push_str("|-------|-----------|------------|\n");
+
+    let mut stages: Vec<_> = by_stage.iter().collect();
+    stages.sort_by(|a, b| b.1.partial_cmp(a.1).unwrap());
+
+    for (stage, cost) in &stages {
+        let pct = if grand_total > 0.0 {
+            *cost / grand_total * 100.0
+        } else {
+            0.0
+        };
+        md.push_str(&format!(
+            "| {} | ${:>8.4} | {:>9.1}% |\n",
+            stage, cost, pct
+        ));
+    }
+    md.push('\n');
+
+    // Per-bookmark table
+    md.push_str("## Per-Bookmark Costs\n\n");
+    md.push_str("| Bookmark ID | Category | Finance | Cost (USD) | Stages |\n");
+    md.push_str("|-------------|----------|---------|-----------|--------|\n");
+
+    let mut sorted_summaries: Vec<_> = summaries.iter().collect();
+    sorted_summaries.sort_by(|a, b| b.total_cost_usd.partial_cmp(&a.total_cost_usd).unwrap());
+
+    for s in &sorted_summaries {
+        let stages: Vec<_> = s.entries.iter().map(|e| e.stage.as_str()).collect();
+        let stages_str = stages.join(", ");
+        md.push_str(&format!(
+            "| {} | {} | {} | ${:.6} | {} |\n",
+            s.bookmark_id,
+            s.category,
+            if s.is_finance { "yes" } else { "no" },
+            s.total_cost_usd,
+            stages_str,
+        ));
+    }
+
+    md
+}
+
+fn chrono_now() -> String {
+    use std::time::SystemTime;
+    let dur = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = dur.as_secs();
+    // Simple UTC timestamp without chrono crate
+    let days = secs / 86400;
+    let time_of_day = secs % 86400;
+    let hours = time_of_day / 3600;
+    let minutes = (time_of_day % 3600) / 60;
+    let seconds = time_of_day % 60;
+
+    // Approximate date from days since epoch (good enough for reports)
+    let (year, month, day) = days_to_date(days);
+    format!("{year:04}-{month:02}-{day:02} {hours:02}:{minutes:02}:{seconds:02} UTC")
+}
+
+fn days_to_date(days_since_epoch: u64) -> (u64, u64, u64) {
+    // Algorithm from Howard Hinnant's civil_from_days
+    let z = days_since_epoch as i64 + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y as u64, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_cost_cerebras_qwen() {
+        let usage = UsageInfo {
+            provider: "cerebras".to_string(),
+            model: "qwen-3-235b-a22b-instruct-2507".to_string(),
+            input_tokens: 1000,
+            output_tokens: 500,
+        };
+        let cost = compute_cost(&usage);
+        // (1000 * 0.20 + 500 * 0.20) / 1_000_000 = 0.0003
+        assert!((cost - 0.0003).abs() < 1e-10);
+    }
+
+    #[test]
+    fn compute_cost_claude_opus() {
+        let usage = UsageInfo {
+            provider: "claude".to_string(),
+            model: "claude-opus-4-6".to_string(),
+            input_tokens: 2000,
+            output_tokens: 1000,
+        };
+        let cost = compute_cost(&usage);
+        // (2000 * 15.0 + 1000 * 75.0) / 1_000_000 = 0.105
+        assert!((cost - 0.105).abs() < 1e-10);
+    }
+
+    #[test]
+    fn compute_cost_openai_gpt5() {
+        let usage = UsageInfo {
+            provider: "openai".to_string(),
+            model: "gpt-5.4".to_string(),
+            input_tokens: 3000,
+            output_tokens: 1500,
+        };
+        let cost = compute_cost(&usage);
+        // (3000 * 2.0 + 1500 * 8.0) / 1_000_000 = 0.018
+        assert!((cost - 0.018).abs() < 1e-10);
+    }
+
+    #[test]
+    fn compute_cost_xai_grok4() {
+        let usage = UsageInfo {
+            provider: "xai".to_string(),
+            model: "grok-4-0709".to_string(),
+            input_tokens: 1000,
+            output_tokens: 500,
+        };
+        let cost = compute_cost(&usage);
+        // (1000 * 3.0 + 500 * 15.0) / 1_000_000 = 0.0105
+        assert!((cost - 0.0105).abs() < 1e-10);
+    }
+
+    #[test]
+    fn cost_tracker_accumulates() {
+        let tracker = CostTracker::new();
+        tracker.record("tweet-1", "classify", &UsageInfo {
+            provider: "cerebras".to_string(),
+            model: "qwen-3-235b".to_string(),
+            input_tokens: 500,
+            output_tokens: 200,
+        });
+        tracker.record("tweet-1", "plan", &UsageInfo {
+            provider: "claude".to_string(),
+            model: "claude-opus-4-6".to_string(),
+            input_tokens: 1000,
+            output_tokens: 500,
+        });
+
+        let entries = tracker.entries();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].stage, "classify");
+        assert_eq!(entries[1].stage, "plan");
+        assert!(tracker.total_cost() > 0.0);
+    }
+
+    #[test]
+    fn cost_tracker_to_json_structure() {
+        let tracker = CostTracker::new();
+        tracker.record("tweet-1", "classify", &UsageInfo {
+            provider: "cerebras".to_string(),
+            model: "qwen-3-235b".to_string(),
+            input_tokens: 100,
+            output_tokens: 50,
+        });
+        let json = tracker.to_json();
+        assert!(json["total_cost_usd"].is_string());
+        assert!(json["calls"].is_array());
+        assert_eq!(json["total_input_tokens"], 100);
+        assert_eq!(json["total_output_tokens"], 50);
+    }
+
+    #[test]
+    fn generate_cost_report_produces_markdown() {
+        let summaries = vec![
+            RunCostSummary {
+                bookmark_id: "tweet-1".to_string(),
+                category: "finance".to_string(),
+                is_finance: true,
+                total_cost_usd: 0.05,
+                entries: vec![CostEntry {
+                    bookmark_id: "tweet-1".to_string(),
+                    stage: "classify".to_string(),
+                    provider: "cerebras".to_string(),
+                    model: "qwen-3-235b".to_string(),
+                    input_tokens: 500,
+                    output_tokens: 200,
+                    cost_usd: 0.0001,
+                }, CostEntry {
+                    bookmark_id: "tweet-1".to_string(),
+                    stage: "plan".to_string(),
+                    provider: "claude".to_string(),
+                    model: "opus".to_string(),
+                    input_tokens: 2000,
+                    output_tokens: 500,
+                    cost_usd: 0.0499,
+                }],
+            },
+            RunCostSummary {
+                bookmark_id: "tweet-2".to_string(),
+                category: "technology".to_string(),
+                is_finance: false,
+                total_cost_usd: 0.001,
+                entries: vec![CostEntry {
+                    bookmark_id: "tweet-2".to_string(),
+                    stage: "classify".to_string(),
+                    provider: "cerebras".to_string(),
+                    model: "qwen-3-235b".to_string(),
+                    input_tokens: 300,
+                    output_tokens: 100,
+                    cost_usd: 0.001,
+                }],
+            },
+        ];
+        let report = generate_cost_report(&summaries);
+        assert!(report.contains("# LLM Cost Report"));
+        assert!(report.contains("Cost by Provider"));
+        assert!(report.contains("Per-Bookmark Costs"));
+        assert!(report.contains("tweet-1"));
+        assert!(report.contains("tweet-2"));
+        assert!(report.contains("cerebras"));
+        assert!(report.contains("claude"));
+    }
+
+    #[test]
+    fn days_to_date_epoch() {
+        let (y, m, d) = days_to_date(0);
+        assert_eq!((y, m, d), (1970, 1, 1));
+    }
+
+    #[test]
+    fn days_to_date_known_date() {
+        // 2026-03-16 is day 20528 since epoch
+        let (y, m, d) = days_to_date(20528);
+        assert_eq!((y, m, d), (2026, 3, 16));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod browser;
 pub mod cache;
 pub mod classifier;
+pub mod cost;
 pub mod cli;
 pub mod config;
 pub mod error;

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,3 +1,4 @@
+use crate::cost::{CostTracker, UsageInfo};
 use crate::error::PipelineError;
 use crate::parser;
 use crate::models::{
@@ -16,6 +17,8 @@ pub type LlmFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, PipelineError>
 
 pub trait LLMProvider: Send + Sync {
     fn name(&self) -> &'static str;
+
+    fn set_cost_tracker(&mut self, _tracker: CostTracker) {}
 
     fn classify<'a>(
         &'a self,
@@ -52,6 +55,7 @@ pub struct BaseLLMProvider {
     timeout_ms: u64,
     client: Client,
     flavor: ApiFlavor,
+    cost_tracker: Option<CostTracker>,
 }
 
 impl BaseLLMProvider {
@@ -73,7 +77,13 @@ impl BaseLLMProvider {
             timeout_ms: 120_000,
             client,
             flavor,
+            cost_tracker: None,
         }
+    }
+
+    pub fn with_cost_tracker(mut self, tracker: CostTracker) -> Self {
+        self.cost_tracker = Some(tracker);
+        self
     }
 
     fn endpoint_url(&self) -> String {
@@ -146,29 +156,41 @@ impl BaseLLMProvider {
         }
     }
 
-    fn extract_text_from_response(&self, body: &str) -> Result<String, PipelineError> {
+    fn extract_text_from_response(&self, body: &str) -> Result<(String, UsageInfo), PipelineError> {
         match self.flavor {
             ApiFlavor::OpenAiCompatible => {
                 let envelope: OpenAIChatResponse = serde_json::from_str(body)?;
                 let mut out = String::new();
-                for choice in envelope.choices {
-                    if let Some(content) = choice.message.content {
-                        out.push_str(&content);
+                for choice in &envelope.choices {
+                    if let Some(content) = &choice.message.content {
+                        out.push_str(content);
                     }
                 }
-                Ok(strip_markdown_fence(&out).to_string())
+                let usage = UsageInfo {
+                    provider: self.name.to_string(),
+                    model: self.model.clone(),
+                    input_tokens: envelope.usage.as_ref().and_then(|u| u.prompt_tokens).unwrap_or(0),
+                    output_tokens: envelope.usage.as_ref().and_then(|u| u.completion_tokens).unwrap_or(0),
+                };
+                Ok((strip_markdown_fence(&out).to_string(), usage))
             }
             ApiFlavor::Anthropic => {
                 let envelope: AnthropicChatResponse = serde_json::from_str(body)?;
                 let mut out = String::new();
-                for block in envelope.content {
+                for block in &envelope.content {
                     if block.block_type == "text" {
-                        if let Some(text) = block.text {
-                            out.push_str(&text);
+                        if let Some(text) = &block.text {
+                            out.push_str(text);
                         }
                     }
                 }
-                Ok(strip_markdown_fence(&out).to_string())
+                let usage = UsageInfo {
+                    provider: self.name.to_string(),
+                    model: self.model.clone(),
+                    input_tokens: envelope.usage.as_ref().and_then(|u| u.input_tokens).unwrap_or(0),
+                    output_tokens: envelope.usage.as_ref().and_then(|u| u.output_tokens).unwrap_or(0),
+                };
+                Ok((strip_markdown_fence(&out).to_string(), usage))
             }
         }
     }
@@ -179,6 +201,7 @@ impl BaseLLMProvider {
         user_prompt: &str,
         with_json_object: bool,
         image_urls: Option<&[String]>,
+        stage: &str,
     ) -> Result<String, PipelineError> {
         let payload = self.build_payload(system_prompt, user_prompt, with_json_object, image_urls);
         let request = match self.flavor {
@@ -216,13 +239,23 @@ impl BaseLLMProvider {
             });
         }
 
-        self.extract_text_from_response(&body)
+        let (text, usage) = self.extract_text_from_response(&body)?;
+
+        if let Some(tracker) = &self.cost_tracker {
+            tracker.record_active(stage, &usage);
+        }
+
+        Ok(text)
     }
 }
 
 impl LLMProvider for BaseLLMProvider {
     fn name(&self) -> &'static str {
         self.name
+    }
+
+    fn set_cost_tracker(&mut self, tracker: CostTracker) {
+        self.cost_tracker = Some(tracker);
     }
 
     fn classify<'a>(
@@ -243,7 +276,7 @@ impl LLMProvider for BaseLLMProvider {
 
         Box::pin(async move {
             let text = self
-                .request_text(system_prompt, &body, true, None)
+                .request_text(system_prompt, &body, true, None, "classify")
                 .await
                 .map_err(PipelineError::from)?;
             let mut result = parse_with_fallback::<ClassificationResult>(
@@ -281,7 +314,7 @@ impl LLMProvider for BaseLLMProvider {
 
         Box::pin(async move {
             let raw_json = self
-                .request_text(system_prompt, &body, true, Some(&image_urls))
+                .request_text(system_prompt, &body, true, Some(&image_urls), "vision")
                 .await
                 .map_err(PipelineError::from)?;
             Ok(parse_image_output(&raw_json))
@@ -296,7 +329,7 @@ impl LLMProvider for BaseLLMProvider {
         let body = serde_json::to_string(&input.plan).unwrap_or_else(|_| "{}".to_string());
         Box::pin(async move {
             let text = self
-                .request_text(system_prompt, &body, false, None)
+                .request_text(system_prompt, &body, false, None, "generate")
                 .await
                 .map_err(PipelineError::from)?;
             Ok(parse_generated_code(&text).unwrap_or_else(|| CodeGenOutput {
@@ -309,7 +342,7 @@ impl LLMProvider for BaseLLMProvider {
 
     fn complete_json<'a>(&'a self, system_prompt: &'a str, user_prompt: &'a str) -> LlmFuture<'a, String> {
         Box::pin(async move {
-            self.request_text(system_prompt, user_prompt, true, None)
+            self.request_text(system_prompt, user_prompt, true, None, "plan")
                 .await
                 .map_err(PipelineError::from)
         })
@@ -407,6 +440,10 @@ macro_rules! delegate_provider {
                 self.inner.name()
             }
 
+            fn set_cost_tracker(&mut self, tracker: CostTracker) {
+                self.inner.set_cost_tracker(tracker);
+            }
+
             fn classify<'a>(
                 &'a self,
                 input: ClassificationInput,
@@ -458,8 +495,16 @@ struct OpenAIChoice {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+struct OpenAIUsage {
+    prompt_tokens: Option<u64>,
+    completion_tokens: Option<u64>,
+    total_tokens: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 struct OpenAIChatResponse {
     choices: Vec<OpenAIChoice>,
+    usage: Option<OpenAIUsage>,
 }
 
 #[cfg(test)]
@@ -633,8 +678,15 @@ struct AnthropicBlock {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+struct AnthropicUsage {
+    input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 struct AnthropicChatResponse {
     content: Vec<AnthropicBlock>,
+    usage: Option<AnthropicUsage>,
 }
 
 fn parse_generated_code(text: &str) -> Option<CodeGenOutput> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ use x_bookmarks_pipeline_rust::{
     notify::{EmailConfig, SmtpNotifier},
     orchestrator::{OnMetaSaved, Pipeline},
 };
+use x_bookmarks_pipeline_rust::browser::{AutoConsentConfig, AutoConsentOutcome};
+use x_bookmarks_pipeline_rust::cost::{CostTracker, RunCostSummary, generate_cost_report};
 use x_bookmarks_pipeline_rust::error::PipelineError;
 
 #[derive(Clone, Debug)]
@@ -210,7 +212,47 @@ fn build_oauth_authorization_url(
     )
 }
 
+fn chrome_user_data_dir() -> Option<std::path::PathBuf> {
+    env_any(&["XPB_CHROME_USER_DATA_DIR", "CHROME_USER_DATA_DIR"])
+        .map(std::path::PathBuf::from)
+}
+
+fn chrome_binary() -> String {
+    env_any(&["XPB_CHROME_BINARY", "CHROME_BINARY"])
+        .unwrap_or_else(|| {
+            if cfg!(target_os = "macos") {
+                "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome".to_string()
+            } else if cfg!(target_os = "windows") {
+                "chrome.exe".to_string()
+            } else {
+                "google-chrome".to_string()
+            }
+        })
+}
+
+/// Open URL in Chrome with remote debugging enabled if a dedicated
+/// user-data-dir is configured. Falls back to default browser otherwise.
 fn open_in_browser(url: &str) -> bool {
+    if let Some(data_dir) = chrome_user_data_dir() {
+        let status = Command::new(chrome_binary())
+            .arg(format!("--user-data-dir={}", data_dir.display()))
+            .arg("--remote-debugging-port=0")
+            .arg(url)
+            .spawn();
+        match status {
+            Ok(_) => {
+                eprintln!(
+                    "[cdp] launched Chrome with remote debugging (user-data-dir={})",
+                    data_dir.display()
+                );
+                return true;
+            }
+            Err(e) => {
+                eprintln!("[cdp] Chrome launch failed: {e}; falling back to default browser");
+            }
+        }
+    }
+
     let status = if cfg!(target_os = "macos") {
         Command::new("open").arg(url).status()
     } else if cfg!(target_os = "windows") {
@@ -375,7 +417,40 @@ async fn start_interactive_reauth_flow(
     write_oauth_state(&state)?;
     emit_auth_flow_instructions(&client_id, &redirect_uri, &scope, &state.code_verifier, &url);
 
+    // Spawn CDP auto-consent task concurrently with the callback listener.
+    // If a chrome_user_data_dir is configured, the CDP task will connect to
+    // Chrome's DevTools WebSocket and click "Authorize app" automatically.
+    let auto_consent_handle = if let Some(data_dir) = chrome_user_data_dir() {
+        let auth_url = url.clone();
+        Some(tokio::spawn(async move {
+            let cfg = AutoConsentConfig {
+                expected_auth_url: auth_url,
+                chrome_user_data_dir: data_dir,
+                overall_timeout: Duration::from_secs(110),
+                poll_interval: Duration::from_millis(500),
+            };
+            match x_bookmarks_pipeline_rust::browser::auto_click_oauth_consent(cfg).await {
+                Ok(AutoConsentOutcome::Clicked { strategy }) =>
+                    eprintln!("[cdp] auto-consent succeeded via {strategy}"),
+                Ok(AutoConsentOutcome::ManualFallback(reason)) =>
+                    eprintln!("[cdp] auto-consent unavailable: {reason}"),
+                Ok(AutoConsentOutcome::TimedOut) =>
+                    eprintln!("[cdp] auto-consent timed out; waiting for manual click"),
+                Err(e) =>
+                    eprintln!("[cdp] auto-consent error: {e}"),
+            }
+        }))
+    } else {
+        None
+    };
+
     let code = wait_for_oauth_code(&redirect_uri, &state.state).await?;
+
+    // Abort the CDP task once the callback arrives (or times out)
+    if let Some(handle) = auto_consent_handle {
+        handle.abort();
+    }
+
     let Some(code) = code else {
         return Ok(false);
     };
@@ -1079,31 +1154,103 @@ async fn run_cycle(
     Ok(results)
 }
 
+fn write_cost_report(
+    tracker: &CostTracker,
+    results: &[PipelineResultModel],
+    output_dir: &str,
+) -> anyhow::Result<()> {
+    let entries = tracker.entries();
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    // Build per-bookmark summaries
+    let mut bookmark_entries: std::collections::HashMap<String, Vec<x_bookmarks_pipeline_rust::cost::CostEntry>> =
+        std::collections::HashMap::new();
+    for entry in &entries {
+        bookmark_entries
+            .entry(entry.bookmark_id.clone())
+            .or_default()
+            .push(entry.clone());
+    }
+
+    let summaries: Vec<RunCostSummary> = results
+        .iter()
+        .filter_map(|r| {
+            let bm_entries = bookmark_entries.remove(&r.tweet_id)?;
+            let total_cost: f64 = bm_entries.iter().map(|e| e.cost_usd).sum();
+            let (category, is_finance) = match &r.classification {
+                Some(c) => (c.category.clone(), c.is_finance),
+                None => ("unknown".to_string(), false),
+            };
+            Some(RunCostSummary {
+                bookmark_id: r.tweet_id.clone(),
+                category,
+                is_finance,
+                total_cost_usd: total_cost,
+                entries: bm_entries,
+            })
+        })
+        .collect();
+
+    if summaries.is_empty() {
+        return Ok(());
+    }
+
+    let report = generate_cost_report(&summaries);
+    let report_path = std::path::Path::new(output_dir).join("cost_report.md");
+    std::fs::create_dir_all(output_dir)?;
+    std::fs::write(&report_path, &report)?;
+
+    let total_cost: f64 = summaries.iter().map(|s| s.total_cost_usd).sum();
+    eprintln!(
+        "[cost] report written to {} (total: ${:.4}, {} bookmarks with LLM calls)",
+        report_path.display(),
+        total_cost,
+        summaries.len(),
+    );
+
+    Ok(())
+}
+
 fn pipeline_providers(
     shared_http: Client,
+    cost_tracker: Option<&x_bookmarks_pipeline_rust::cost::CostTracker>,
 ) -> anyhow::Result<(
     Arc<dyn LLMProvider>,
     Arc<dyn LLMProvider>,
     Arc<dyn LLMProvider>,
     Arc<dyn LLMProvider>,
 )> {
+    let mut cerebras = CerebrasProvider::new(
+        require_env("CEREBRAS_API_KEY", &[])?,
+        shared_http.clone(),
+    );
+    let mut xai = XaiProvider::new(
+        require_env("XAI_API_KEY", &[])?,
+        shared_http.clone(),
+    );
+    let mut claude = ClaudeProvider::new(
+        require_env("ANTHROPIC_API_KEY", &[])?,
+        shared_http.clone(),
+    );
+    let mut openai = OpenAIProvider::new(
+        require_env("OPENAI_API_KEY", &[])?,
+        shared_http,
+    );
+
+    if let Some(tracker) = cost_tracker {
+        cerebras.set_cost_tracker(tracker.clone());
+        xai.set_cost_tracker(tracker.clone());
+        claude.set_cost_tracker(tracker.clone());
+        openai.set_cost_tracker(tracker.clone());
+    }
+
     Ok((
-        Arc::new(CerebrasProvider::new(
-            require_env("CEREBRAS_API_KEY", &[])?,
-            shared_http.clone(),
-        )),
-        Arc::new(XaiProvider::new(
-            require_env("XAI_API_KEY", &[])?,
-            shared_http.clone(),
-        )),
-        Arc::new(ClaudeProvider::new(
-            require_env("ANTHROPIC_API_KEY", &[])?,
-            shared_http.clone(),
-        )),
-        Arc::new(OpenAIProvider::new(
-            require_env("OPENAI_API_KEY", &[])?,
-            shared_http,
-        )),
+        Arc::new(cerebras),
+        Arc::new(xai),
+        Arc::new(claude),
+        Arc::new(openai),
     ))
 }
 
@@ -1228,7 +1375,8 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    let providers = pipeline_providers(shared_http.clone())?;
+    let cost_tracker = CostTracker::new();
+    let providers = pipeline_providers(shared_http.clone(), Some(&cost_tracker))?;
     let mut fetcher = build_fetcher(&args, &cfg, &mut refresh_config).await?;
     let notifier = build_notifier();
     if notifier.is_some() {
@@ -1255,7 +1403,8 @@ async fn main() -> Result<()> {
         .with_cache(!args.no_cache)
         .with_vision(!args.no_vision)
         .with_verbose(args.verbose)
-        .with_on_meta_saved(hook),
+        .with_on_meta_saved(hook)
+        .with_cost_tracker(cost_tracker.clone()),
     );
 
     let daemon_mode = args.daemon || env_flag(&["XPB_DAEMON", "DAEMON_MODE"]);
@@ -1279,7 +1428,8 @@ async fn main() -> Result<()> {
     };
 
     if !daemon_mode {
-        let _ = run_cycle(&pipeline, &mut fetcher, &shared_http, &mut refresh_config, &args).await?;
+        let results = run_cycle(&pipeline, &mut fetcher, &shared_http, &mut refresh_config, &args).await?;
+        write_cost_report(&cost_tracker, &results, &cfg.output_dir)?;
         return Ok(());
     }
 

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -1,6 +1,7 @@
 use crate::cache::BookmarkCache;
 use crate::classifier::FinanceClassifier;
 use crate::config::AppConfig;
+use crate::cost::CostTracker;
 use crate::error::{PipelineError, PipelineResult};
 use crate::generator::PineScriptGenerator;
 use crate::llm::LLMProvider;
@@ -34,6 +35,7 @@ pub struct Pipeline {
     max_parallel_workers: usize,
     verbose: bool,
     on_meta_saved: Option<OnMetaSaved>,
+    cost_tracker: Option<CostTracker>,
 }
 
 impl Pipeline {
@@ -60,7 +62,13 @@ impl Pipeline {
             max_parallel_workers: config.max_workers.max(1),
             verbose: false,
             on_meta_saved: None,
+            cost_tracker: None,
         }
+    }
+
+    pub fn with_cost_tracker(mut self, tracker: CostTracker) -> Self {
+        self.cost_tracker = Some(tracker);
+        self
     }
 
     pub fn with_cache(mut self, enabled: bool) -> Self {
@@ -124,6 +132,10 @@ impl Pipeline {
     pub async fn run(&self, mut bookmark: Bookmark, save: bool) -> PipelineRunResult {
         let mut result = PipelineRunResult::new(&bookmark.id);
         self.log(&bookmark.id, "run", "starting pipeline");
+
+        if let Some(tracker) = &self.cost_tracker {
+            tracker.set_active_bookmark(&bookmark.id);
+        }
 
         if self.cache_enabled {
             self.log(&bookmark.id, "cache", "cache enabled, checking completed state");
@@ -566,6 +578,15 @@ impl Pipeline {
         let out_dir = self.output_directory(classification);
         fs::create_dir_all(&out_dir).await?;
 
+        let cost_json = self.cost_tracker.as_ref().map(|t| {
+            let entries: Vec<_> = t.entries().into_iter().filter(|e| e.bookmark_id == bookmark.id).collect();
+            let total: f64 = entries.iter().map(|e| e.cost_usd).sum();
+            serde_json::json!({
+                "total_cost_usd": format!("{:.6}", total),
+                "calls": entries,
+            })
+        });
+
         let meta = serde_json::json!({
             "tweet_id": bookmark.id,
             "tweet_url": bookmark.tweet_url,
@@ -588,6 +609,7 @@ impl Pipeline {
             "pattern": plan.and_then(|p| p.pattern.clone()),
             "key_levels": plan.map(|p| p.key_levels.clone()),
             "rationale": plan.map(|p| p.rationale.clone()),
+            "cost": cost_json,
         });
 
         let path = self.meta_path_for_bookmark(bookmark, classification);
@@ -629,6 +651,15 @@ impl Pipeline {
         let mut meta_path = pine_path.clone();
         meta_path.set_extension("meta.json");
 
+        let cost_json = self.cost_tracker.as_ref().map(|t| {
+            let entries: Vec<_> = t.entries().into_iter().filter(|e| e.bookmark_id == bookmark.id).collect();
+            let total: f64 = entries.iter().map(|e| e.cost_usd).sum();
+            serde_json::json!({
+                "total_cost_usd": format!("{:.6}", total),
+                "calls": entries,
+            })
+        });
+
         let meta = serde_json::json!({
             "tweet_id": bookmark.id,
             "tweet_url": bookmark.tweet_url,
@@ -648,6 +679,7 @@ impl Pipeline {
             "validation_passed": validation.valid,
             "validation_errors": validation.errors,
             "validation_warnings": validation.warnings,
+            "cost": cost_json,
         });
 
         if fs::write(


### PR DESCRIPTION
## Summary

- **Cost tracking**: Captures `prompt_tokens` and `completion_tokens` from every LLM API response (Cerebras, xAI, Claude, OpenAI), computes USD costs using per-provider/per-model pricing tables, and attaches a `cost` object to each bookmark's `.meta.json`
- **Cost report**: Generates `output/cost_report.md` after each pipeline run with YTD summary by provider, by pipeline stage, and per-bookmark breakdown table
- **CDP auto-consent**: New `browser.rs` module that auto-clicks "Authorize app" on the X OAuth consent page via Chrome DevTools Protocol when the daemon's token expires
- **README overhaul**: Updated with OAuth reauth docs, CDP setup, dependency table, correct repo structure

## New files

| File | Purpose |
|---|---|
| `src/cost.rs` | `UsageInfo`, `CostTracker`, `CostEntry`, pricing tables, cost report generation (9 unit tests) |
| `src/browser.rs` | CDP WebSocket client, auto-consent flow (28 unit + integration tests) |

## Key changes

| File | Change |
|---|---|
| `src/llm.rs` | Added `usage` fields to API response structs, `extract_text_from_response` now returns `(String, UsageInfo)`, providers record usage via shared `CostTracker` |
| `src/orchestrator.rs` | `Pipeline` sets active bookmark context for cost attribution, attaches `cost` JSON to both `save_meta` and `save_finance` output |
| `src/main.rs` | Creates `CostTracker`, passes to providers and pipeline, generates `cost_report.md` after non-daemon runs; also includes CDP auto-consent integration |

## Test plan

- [x] `cargo test` — 74 tests pass (69 lib + 4 main + 1 integration)
- [x] `cargo build --release` — clean build
- [ ] Manual: run pipeline with `--fetch --save`, verify `cost` field in `.meta.json` files
- [ ] Manual: verify `output/cost_report.md` is generated with correct breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)